### PR TITLE
Xcode 26 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 iOS Swift development IDE for Windows/Linux. Create, build, and test apps without owning a Mac.
 
-Supports Swift 6.1 and the Swift Package Manager.
+Supports Swift 6.2 and the Swift Package Manager.
 
 ### Demo
 
@@ -30,7 +30,7 @@ Check out the [Getting Started](https://github.com/nab138/CrossCode/wiki#getting
 
 ## Features
 
-- Generate a Darwin SDK for linux from a user provided copy of Xcode 16.3 to build the apps
+- Generate a Darwin SDK for linux from a user provided copy of Xcode 26 to build the apps
 - Build apps using swift package manager
 - Log in with your Apple ID to sign apps
 - Install apps on device
@@ -49,7 +49,7 @@ Please note that I am one person, so development may be slow. If you want to hel
 
 ## How it works
 
-- A darwin SDK is generated from a user provided copy of Xcode 16.3 (extracted with [unxip-rs](https://github.com/nab138/unxip-rs)) and darwin tools from [darwin-tools-linux-llvm](https://github.com/xtool-org/darwin-tools-linux-llvm)
+- A darwin SDK is generated from a user provided copy of Xcode 26 (extracted with [unxip-rs](https://github.com/nab138/unxip-rs)) and darwin tools from [darwin-tools-linux-llvm](https://github.com/xtool-org/darwin-tools-linux-llvm)
 - Swift uses the darwin SDK to build an executable which is packaged into an .app bundle.
 - The code to sign and install apps onto a device has been removed from CrossCode's source and moved to a standalone package, [isideload](https://github.com/nab138/isideload). It was built on a lot of other libraries, so check out its README for more info.
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,16 +20,16 @@
         "@mui/icons-material": "^7.0.2",
         "@mui/joy": "^5.0.0-beta.52",
         "@mui/material": "^7.0.2",
-        "@tauri-apps/api": "~2",
+        "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-cli": "^2.4.0",
-        "@tauri-apps/plugin-dialog": "~2",
-        "@tauri-apps/plugin-fs": "~2",
-        "@tauri-apps/plugin-opener": "~2",
+        "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-fs": "^2",
+        "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-os": "^2.3.0",
         "@tauri-apps/plugin-process": "^2.3.0",
-        "@tauri-apps/plugin-shell": "~2",
-        "@tauri-apps/plugin-store": "~2",
-        "@tauri-apps/plugin-updater": "~2",
+        "@tauri-apps/plugin-shell": "^2",
+        "@tauri-apps/plugin-store": "^2",
+        "@tauri-apps/plugin-updater": "^2",
         "ansi-to-html": "^0.7.2",
         "async-mutex": "^0.5.0",
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~20.2.1",
@@ -44,13 +44,13 @@
         "vscode-ws-jsonrpc": "^3.4.0",
       },
       "devDependencies": {
-        "@tauri-apps/cli": "~2",
+        "@tauri-apps/cli": "^2",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@types/vscode": "^1.102.0",
         "@vitejs/plugin-react": "^4.2.1",
         "typescript": "^5.0.2",
-        "vite": "^7.0.0",
+        "vite": "^7.1.6",
       },
     },
   },
@@ -699,7 +699,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -707,7 +707,7 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.1.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw=="],
 
-    "vite": ["vite@7.1.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.14" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw=="],
+    "vite": ["vite@7.1.6", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-SRYIB8t/isTwNn8vMB3MR6E+EQZM/WG1aKmmIUCfDXfVvKfc20ZpamngWHKzAmmu9ppsgxsg4b2I7c90JZudIQ=="],
 
     "vscode": ["@codingame/monaco-vscode-extension-api@20.2.1", "", { "dependencies": { "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "20.2.1", "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "20.2.1", "@codingame/monaco-vscode-api": "20.2.1", "@codingame/monaco-vscode-extensions-service-override": "20.2.1" } }, "sha512-K2VFVhQZUpBS+YJRr4DYgvNjelu7dWw81YWg8PwEVj7X8vSd9DqQZbTvudsiJDhlkkY4KWqZQjtITY0fc/X3QQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "@types/vscode": "^1.102.0",
     "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.0.2",
-    "vite": "^7.0.0"
+    "vite": "^7.1.6"
   }
 }

--- a/src-tauri/src/lsp_utils.rs
+++ b/src-tauri/src/lsp_utils.rs
@@ -32,7 +32,7 @@ pub fn validate_project(project_path: String, toolchain_path: String) -> Project
 //     let config_path = project_path.join(".sourcekit-lsp").join("config.json");
 //     if !config_path.exists() {
 //         fs::write(config_path, "{
-//   \"$schema\": \"https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/release/6.1/config.schema.json\",
+//   \"$schema\": \"https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/release/6.2/config.schema.json\",
 //   \"swiftPM\": {
 //     \"swiftSDK\": \"arm64-apple-ios\"
 //   }

--- a/src-tauri/templates/swiftui/Package.swift
+++ b/src-tauri/templates/swiftui/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/src-tauri/templates/uikit/Package.swift
+++ b/src-tauri/templates/uikit/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/src/components/SDKMenu.tsx
+++ b/src/components/SDKMenu.tsx
@@ -7,11 +7,13 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { installSdkOperation } from "../utilities/operations";
 import ErrorIcon from "@mui/icons-material/Error";
 import WarningIcon from "@mui/icons-material/Warning";
+import { DARWIN_SDK_VERSION } from "../utilities/constants";
 
 export default () => {
   const {
     selectedToolchain,
     hasDarwinSDK,
+    darwinSDKVersion,
     checkSDK,
     startOperation,
     isWindows,
@@ -86,32 +88,46 @@ export default () => {
         gap: "var(--padding-md)",
       }}
     >
-      <Typography
-        level="body-md"
-        color={
-          hasDarwinSDK ? "success" : selectedToolchain ? "danger" : "warning"
-        }
-        sx={{
-          alignContent: "center",
-          display: "flex",
-          gap: "var(--padding-xs)",
-        }}
-      >
-        {isWindowsReady ? (
-          hasDarwinSDK ? (
-            "Darwin SDK is installed!"
+      <div>
+        <Typography
+          level="body-md"
+          color={
+            hasDarwinSDK ? "success" : selectedToolchain ? "danger" : "warning"
+          }
+          sx={{
+            alignContent: "center",
+            display: "flex",
+            gap: "var(--padding-xs)",
+          }}
+        >
+          {isWindowsReady ? (
+            hasDarwinSDK ? (
+              "Darwin SDK is installed!"
+            ) : (
+              <>
+                {selectedToolchain ? <ErrorIcon /> : <WarningIcon />}
+                {selectedToolchain
+                  ? "Darwin SDK is not installed"
+                  : "Select a swift toolchain first"}
+              </>
+            )
           ) : (
-            <>
-              {selectedToolchain ? <ErrorIcon /> : <WarningIcon />}
-              {selectedToolchain
-                ? "Darwin SDK is not installed"
-                : "Select a swift toolchain first"}
-            </>
-          )
-        ) : (
-          "Install WSL and Swift first."
+            "Install WSL and Swift first."
+          )}
+        </Typography>
+        {hasDarwinSDK && (
+          <Typography
+            level="body-sm"
+            color={
+              darwinSDKVersion === DARWIN_SDK_VERSION ? undefined : "warning"
+            }
+          >
+            {darwinSDKVersion === DARWIN_SDK_VERSION
+              ? `Version: ${darwinSDKVersion}`
+              : `Unsupported SDK version (${darwinSDKVersion}). Apps may compile, but you may not be able to use newer features (like liquid glass). Please re-install with Xcode 26.`}
+          </Typography>
         )}
-      </Typography>
+      </div>
       <div
         style={{
           display: "flex",

--- a/src/components/SDKMenu.tsx
+++ b/src/components/SDKMenu.tsx
@@ -123,11 +123,11 @@ export default () => {
           onClick={(e) => {
             e.preventDefault();
             openUrl(
-              "https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_16.3/Xcode_16.3.xip"
+              "https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_26/Xcode_26_Universal.xip"
             );
           }}
         >
-          Download XCode 16.3
+          Download XCode 26
         </Button>
         <Button
           variant="soft"

--- a/src/components/SwiftMenu.tsx
+++ b/src/components/SwiftMenu.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import ErrorIcon from "@mui/icons-material/Error";
 import { invoke } from "@tauri-apps/api/core";
+import { SWIFT_VERSION_PREFIX } from "../utilities/constants";
 
 export default () => {
   const {
@@ -92,7 +93,7 @@ export default () => {
               fontFamily: "monospace",
             }}
           >
-            swiftly install 6.2
+            swiftly install {SWIFT_VERSION_PREFIX}
           </span>
           " or manually. If you have already done so, but it is not showing up,
           your toolchain installation may be broken. For help, refer to the{" "}
@@ -110,7 +111,13 @@ export default () => {
           .
         </Typography>
       )}
-
+      {selectedToolchain !== null && !isCompatable(selectedToolchain) && (
+        <Typography level="body-md" color="danger">
+          Your selected toolchain is not compatible. Please select a swift{" "}
+          {SWIFT_VERSION_PREFIX}
+          toolchain.
+        </Typography>
+      )}
       {toolchains !== null && allToolchains.length > 0 && (
         <div>
           <Typography level="body-md">Select a toolchain:</Typography>
@@ -198,7 +205,7 @@ export default () => {
 
 export function isCompatable(toolchain: Toolchain | null): boolean {
   if (!toolchain) return false;
-  return toolchain.version.startsWith("6.2");
+  return toolchain.version.startsWith(SWIFT_VERSION_PREFIX);
 }
 
 function stringifyToolchain(toolchain: Toolchain | null): string | null {

--- a/src/components/SwiftMenu.tsx
+++ b/src/components/SwiftMenu.tsx
@@ -92,7 +92,7 @@ export default () => {
               fontFamily: "monospace",
             }}
           >
-            swiftly install 6.1
+            swiftly install 6.2
           </span>
           " or manually. If you have already done so, but it is not showing up,
           your toolchain installation may be broken. For help, refer to the{" "}
@@ -110,6 +110,7 @@ export default () => {
           .
         </Typography>
       )}
+
       {toolchains !== null && allToolchains.length > 0 && (
         <div>
           <Typography level="body-md">Select a toolchain:</Typography>
@@ -195,9 +196,9 @@ export default () => {
   );
 };
 
-function isCompatable(toolchain: Toolchain | null): boolean {
+export function isCompatable(toolchain: Toolchain | null): boolean {
   if (!toolchain) return false;
-  return toolchain.version.startsWith("6.1");
+  return toolchain.version.startsWith("6.2");
 }
 
 function stringifyToolchain(toolchain: Toolchain | null): string | null {

--- a/src/pages/IDE.tsx
+++ b/src/pages/IDE.tsx
@@ -46,8 +46,13 @@ export default () => {
   const [redo, setRedo] = useState<(() => void) | null>(null);
   const [theme] = useStore<"light" | "dark">("appearance/theme", "dark");
   const { path } = useParams<"path">();
-  const { openFolderDialog, selectedToolchain, hasLimitedRam, initialized } =
-    useIDE();
+  const {
+    openFolderDialog,
+    selectedToolchain,
+    hasLimitedRam,
+    initialized,
+    ready,
+  } = useIDE();
   const [sourcekitStartup, setSourcekitStartup] = useStore<boolean | null>(
     "sourcekit/startup",
     null
@@ -67,6 +72,17 @@ export default () => {
     useState<ProjectValidation | null>(null);
   const [editor, setEditor] = useState<IStandaloneCodeEditor | null>(null);
   const { addToast } = useToast();
+
+  useEffect(() => {
+    if (ready === false && initialized) {
+      console.log(
+        "IDE not ready, returning to welcome page",
+        ready,
+        initialized
+      );
+      navigate("/");
+    }
+  }, [ready, initialized, navigate]);
 
   useEffect(() => {
     (async () => {

--- a/src/pages/IDE.tsx
+++ b/src/pages/IDE.tsx
@@ -25,6 +25,7 @@ import { restartServer } from "../utilities/lsp-client";
 import BottomBar from "../components/Tiles/BottomBar";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { IStandaloneCodeEditor } from "@codingame/monaco-vscode-api/vscode/vs/editor/standalone/browser/standaloneCodeEditor";
+import { DARWIN_SDK_VERSION } from "../utilities/constants";
 
 export interface IDEProps {}
 
@@ -52,6 +53,7 @@ export default () => {
     hasLimitedRam,
     initialized,
     ready,
+    darwinSDKVersion,
   } = useIDE();
   const [sourcekitStartup, setSourcekitStartup] = useStore<boolean | null>(
     "sourcekit/startup",
@@ -59,6 +61,11 @@ export default () => {
   );
   const [hasIgnoredRam, setHasIgnoredRam] = useStore<boolean>(
     "has-ignored-ram",
+    false
+  );
+
+  const [hasIgnoredDarwinSDK, setHasIgnoredDarwinSDK] = useStore<boolean>(
+    "has-ignored-darwin-sdk",
     false
   );
 
@@ -336,6 +343,54 @@ export default () => {
                   variant="outlined"
                 >
                   Enable Anyway
+                </Button>
+              </div>
+            </ModalDialog>
+          </Modal>
+        )}
+      {initialized &&
+        selectedToolchain !== null &&
+        hasIgnoredDarwinSDK === false &&
+        darwinSDKVersion !== DARWIN_SDK_VERSION && (
+          <Modal
+            open={true}
+            onClose={() => {
+              setHasIgnoredDarwinSDK(true);
+            }}
+          >
+            <ModalDialog sx={{ maxWidth: "90vw" }}>
+              <ModalClose />
+              <div>
+                <div style={{ display: "flex", gap: "var(--padding-md)" }}>
+                  <div style={{ width: "1.25rem" }}>
+                    <WarningIcon />
+                  </div>
+                  <Typography level="h3">Incompatible SDK Version</Typography>
+                </div>
+                <Typography level="body-lg">
+                  This version of CrossCode is designed to work with Darwin SDK{" "}
+                  {DARWIN_SDK_VERSION}, but you have version {darwinSDKVersion}{" "}
+                  installed. Things may still work, but you will miss out on
+                  newer features (like liquid glass) and may run into issues.
+                </Typography>
+              </div>
+
+              <Divider sx={{ mb: "var(--padding-xs)" }} />
+              <div style={{ display: "flex", gap: "var(--padding-lg)" }}>
+                <Button
+                  onClick={() => {
+                    navigate("/#install-sdk");
+                  }}
+                >
+                  Install Correct SDK
+                </Button>
+                <Button
+                  onClick={() => {
+                    setHasIgnoredDarwinSDK(true);
+                  }}
+                  variant="outlined"
+                >
+                  Ignore
                 </Button>
               </div>
             </ModalDialog>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -18,30 +18,10 @@ import { relaunch } from "@tauri-apps/plugin-process";
 export interface OnboardingProps {}
 
 export default ({}: OnboardingProps) => {
-  const {
-    selectedToolchain,
-    toolchains,
-    hasWSL,
-    isWindows,
-    openFolderDialog,
-    hasDarwinSDK,
-  } = useIDE();
-  const [ready, setReady] = useState(false);
+  const { ready, hasWSL, isWindows, openFolderDialog } = useIDE();
   const [version, setVersion] = useState<string>("");
   const navigate = useNavigate();
   const { addToast } = useToast();
-
-  useEffect(() => {
-    if (toolchains !== null && isWindows !== null && hasWSL !== null) {
-      setReady(
-        selectedToolchain !== null &&
-          (isWindows ? hasWSL : true) &&
-          hasDarwinSDK
-      );
-    } else {
-      setReady(false);
-    }
-  }, [selectedToolchain, toolchains, hasWSL, isWindows, hasDarwinSDK]);
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -250,7 +230,7 @@ export default ({}: OnboardingProps) => {
         <Card variant="soft">
           <Typography level="h3">Swift</Typography>
           <Typography level="body-sm">
-            You will need a Swift 6.1 toolchain to use CrossCode. It is
+            You will need a Swift 6.2 toolchain to use CrossCode. It is
             recommended to install it using swiftly, but you can also install it
             manually.
           </Typography>
@@ -263,10 +243,10 @@ export default ({}: OnboardingProps) => {
           <Typography level="h3">Darwin SDK</Typography>
           <Typography level="body-sm">
             CrossCode requires a special swift SDK to build apps for iOS. It can
-            be generated from a copy of Xcode 16 or later. To install it,
+            be generated from a copy of Xcode 26 or later. To install it,
             download Xcode.xip using the link below, click the "Install SDK"
             button, then select the downloaded file. Note that installing the
-            SDK will temporarily require a lot of disk space (~10GB) and may
+            SDK will temporarily require a lot of disk space (~11GB) and may
             take a while.
           </Typography>
           <Divider />

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { open } from "@tauri-apps/plugin-shell";
 import "./Onboarding.css";
 import { Button, Card, CardContent, Divider, Link, Typography } from "@mui/joy";
 import { useIDE } from "../utilities/IDEContext";
 import logo from "../assets/logo.png";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import SwiftMenu from "../components/SwiftMenu";
 import SDKMenu from "../components/SDKMenu";
@@ -14,6 +14,7 @@ import { getVersion } from "@tauri-apps/api/app";
 import { invoke } from "@tauri-apps/api/core";
 import { useToast } from "react-toast-plus";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { SWIFT_VERSION_PREFIX } from "../utilities/constants";
 
 export interface OnboardingProps {}
 
@@ -30,6 +31,18 @@ export default ({}: OnboardingProps) => {
     };
     fetchVersion();
   }, []);
+
+  const location = useLocation();
+  const darwinSdkRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    console.log(location.hash);
+    if (location.hash === "#install-sdk" && darwinSdkRef.current) {
+      darwinSdkRef.current.scrollIntoView({
+        block: "start",
+      });
+    }
+  }, [location.hash]);
 
   return (
     <div className="onboarding">
@@ -230,16 +243,16 @@ export default ({}: OnboardingProps) => {
         <Card variant="soft">
           <Typography level="h3">Swift</Typography>
           <Typography level="body-sm">
-            You will need a Swift 6.2 toolchain to use CrossCode. It is
-            recommended to install it using swiftly, but you can also install it
-            manually.
+            You will need a Swift {SWIFT_VERSION_PREFIX} toolchain to use
+            CrossCode. It is recommended to install it using swiftly, but you
+            can also install it manually.
           </Typography>
           <Divider />
           <CardContent>
             <SwiftMenu />
           </CardContent>
         </Card>
-        <Card variant="soft">
+        <Card variant="soft" id="install-sdk">
           <Typography level="h3">Darwin SDK</Typography>
           <Typography level="body-sm">
             CrossCode requires a special swift SDK to build apps for iOS. It can
@@ -255,6 +268,7 @@ export default ({}: OnboardingProps) => {
           </CardContent>
         </Card>
       </div>
+      <div style={{ width: 0, height: 0 }} ref={darwinSdkRef}></div>
     </div>
   );
 };

--- a/src/utilities/StoreContext.tsx
+++ b/src/utilities/StoreContext.tsx
@@ -41,7 +41,13 @@ export const StoreProvider: React.FC<{ children: React.ReactNode }> = ({
       await setTheme(theme as "light" | "dark");
       setMode(theme as "light" | "dark");
 
-      storeInstance.set("isCrossCodePrefs", true);
+      if ((await storeInstance.get("isCrossCodePrefs")) !== true) {
+        storeInstance.set("isCrossCodePrefs", true);
+      } else {
+        if ((await storeInstance.get("lastXcodeVersion")) === undefined) {
+          storeInstance.set("lastXcodeVersion", "16.3");
+        }
+      }
 
       const keys = await storeInstance.keys();
       const values: { [key: string]: any } = {};

--- a/src/utilities/StoreContext.tsx
+++ b/src/utilities/StoreContext.tsx
@@ -41,13 +41,7 @@ export const StoreProvider: React.FC<{ children: React.ReactNode }> = ({
       await setTheme(theme as "light" | "dark");
       setMode(theme as "light" | "dark");
 
-      if ((await storeInstance.get("isCrossCodePrefs")) !== true) {
-        storeInstance.set("isCrossCodePrefs", true);
-      } else {
-        if ((await storeInstance.get("lastXcodeVersion")) === undefined) {
-          storeInstance.set("lastXcodeVersion", "16.3");
-        }
-      }
+      storeInstance.set("isCrossCodePrefs", true);
 
       const keys = await storeInstance.keys();
       const values: { [key: string]: any } = {};

--- a/src/utilities/constants.ts
+++ b/src/utilities/constants.ts
@@ -1,0 +1,2 @@
+export const SWIFT_VERSION_PREFIX = "6.2";
+export const DARWIN_SDK_VERSION = "26.0";


### PR DESCRIPTION
- Changes required swift version to swift 6.2
- Changes links and text to Xcode 26
- Adds a warning if you are using old versions of the darwin sdk